### PR TITLE
[finishes #170800686] Create view specific announcement page

### DIFF
--- a/templates/css/view-announcement.css
+++ b/templates/css/view-announcement.css
@@ -1,0 +1,89 @@
+@import url('https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Roboto:400,700|Source+Sans+Pro:400,700&display=swap');
+
+body {
+    background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(215,195,15,1) 100%);
+    height: 100%;
+    background-repeat: no-repeat;
+    background-attachment: fixed; 
+    font-family: 'Montserrat', sans-serif;
+}
+
+.container {
+    background: #ffffff;
+    width: 90%;
+    margin: 5% auto;
+    padding: 0.2rem;
+}
+
+.title {
+    width: 90%;
+    margin: 0 auto;
+    text-align: center;
+    border-bottom: 2px solid #333333;
+}
+
+.body {
+    width: 90%;
+    margin: 0 auto;
+    padding: 0.5rem;
+}
+
+.body p {
+    line-height: 1.5rem;
+}
+
+.highlight {
+    font-weight: 600;
+}
+
+.status-update, .start-end-date {
+    width: 90%;
+    margin: 2rem auto;
+}
+
+.status-update a {
+    text-decoration: none;
+    background-color: #083343;
+    color: whitesmoke;
+    padding: 0.4rem;
+    border-radius: 5px;
+}
+
+.cancel-button {
+    margin: 1rem;
+    text-align: right;
+}
+
+.cancel-button a {
+    text-decoration: none;
+    background-color: red;
+    color: white;
+    padding: 0.2rem 0.4rem;
+    font-weight: 600;
+}
+
+@media only screen and (min-width: 750px) {
+    .container {
+        width: 60%;
+    }
+}
+
+@media only screen and (min-width: 1000px) {
+    .container {
+        width: 50%;
+    }
+
+    .details {
+        display: flex;
+        flex-direction: row;
+        width: 90%;
+        margin: 0 auto;
+        justify-content: space-evenly;
+    }
+}
+
+@media only screen and (min-width: 1800px) {
+    .container {
+        width: 40%;
+    }
+}

--- a/templates/html/view-announcement.html
+++ b/templates/html/view-announcement.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>AnnounceIT | View announcement</title>
+    <link rel="stylesheet" href="../css/view-announcement.css">
+</head>
+<body>
+    <div class="container">
+        <div class="cancel-button">
+            <a href="./advertiser-dashboard.html">X</a>
+        </div>
+        <div class="announcement">
+            <div class="title">
+                <h3>Lorem Ipsum</h3>
+            </div>
+
+            <div class="body">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ac placerat vestibulum lectus mauris ultrices eros in cursus. Semper quis lectus nulla at volutpat diam ut. At augue eget arcu dictum varius. Placerat in egestas erat imperdiet sed euismod nisi porta lorem. Risus sed vulputate odio ut enim. Diam vel quam elementum pulvinar etiam non quam. Interdum varius sit amet mattis vulputate enim nulla aliquet. Dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum et. Lectus quam id leo in vitae. Pharetra pharetra massa massa ultricies mi. Lorem dolor sed viverra ipsum nunc aliquet bibendum enim. Cras adipiscing enim eu turpis egestas pretium aenean pharetra. Et ultrices neque ornare aenean euismod elementum nisi quis. Turpis egestas integer eget aliquet nibh praesent tristique magna. At tellus at urna condimentum mattis pellentesque. Viverra adipiscing at in tellus integer feugiat scelerisque varius. Purus sit amet luctus venenatis lectus magna. Amet consectetur adipiscing elit pellentesque.
+                </p>
+            </div>
+
+            <div class="details">
+                <div class="start-end-date">
+                    <p id="start-date"><span class="highlight">Start date:</span> 19/09/2019</p>
+                    <p id="end-date"><span class="highlight">End date:</span> 20/01/2019</p>
+                </div>
+                <div class="status-update">
+                    <p><span class="highlight">Status:</span> active</p>
+                    <a href="./update-announcement.html">Update announcement</a>                
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
# What does this PR do/

This is a page that allows users to view a specific announcement

# Description of the task to be completed

- Create a responsive page
- Show the user all the details related to the announcement
- Provide an option to update the announcement

# How should this be manually tested?

- Clone this repository and cd into /templates/html/ and open view-announcement.html
- Resize your browser to check for its responsiveness
- Check the presence of details such as the title, body, start date, end date, status and update announcement button

![view-announcement](https://user-images.githubusercontent.com/52489421/72755049-39f8d080-3bd2-11ea-88d5-64f6b8ae9f02.png)