### PR TITLE
#170801261 Create a form allowing the admin to change an announcement status

### DIFF
--- a/templates/css/admin-dashboard.css
+++ b/templates/css/admin-dashboard.css
@@ -83,7 +83,7 @@ header {
     z-index: 1;
     border: 2px solid #333;
     padding: 0.5rem;
-    margin: 1rem auto;
+    margin: 1.5rem auto;
     border-radius: 5px;
     width: 95%;
 }
@@ -105,6 +105,29 @@ header {
 .body {
     
     padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.change-status-delete {
+    background-color: #288383;
+    color: whitesmoke;
+    height: 3rem;
+    padding: 0.5rem;
+}
+
+select {
+    font-family: 'Montserrat';
+    border: none;
+    height: 2rem;
+    width: 42%;
+}
+
+.status input {
+    border: none;
+    background-color: rgba(215,195,15);
+    color: #083343;
+    height: 2rem;
+    font-weight: 600;
 }
 
 #dehaze {
@@ -181,6 +204,11 @@ header {
     .nav-display {
         width: 60%;
     }
+
+    .status {
+        margin: 0 auto;
+        width: 70%;
+    }
 }
 
 @media only screen and (min-width: 1024px) {
@@ -197,5 +225,9 @@ header {
 
     .wrapper{
         width: 70%;
+    }
+
+    .status {
+        width: 75%;
     }
 }

--- a/templates/html/admin-dashboard.html
+++ b/templates/html/admin-dashboard.html
@@ -51,6 +51,21 @@
                             <div class="body">
                                 <p class="announcement-body">Lorem ipsum dolor sit amet</p>
                             </div>
+                            <div class="change-status-delete">
+                                <div class="status">
+                                    <form action="">
+                                        <label for="change-status">Change status:</label>
+                                        <select name="change-status">
+                                            <option value="change status" selected disabled>Change status</option>
+                                            <option value="active">Active</option>
+                                            <option value="deactivated">Deactivated</option>
+                                            <option value="accepted">Accepted</option>
+                                            <option value="declined">Declined</option>
+                                        </select>
+                                        <input type="submit" value="OK">
+                                    </form>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/templates/js/admin-dashboard.js
+++ b/templates/js/admin-dashboard.js
@@ -66,18 +66,33 @@ const loadAllAnnouncements = () => {
                 return `<div class="announcement">
                 <div class="header">
                     <div class="title">
-                        <h3 class="announcement-title">${announcement.title}</h3>
+                        <h3 class="announcement-title">Lorem Ipsum</h3>
                     </div>
                     <div class="creator-and-status">
-                        <p>Creator: <span id="creator">${user.firstname} ${user.lastname}</span></p>
-                        <p>Status: <span id="status"></span>${announcement.status}</p>
+                        <p>Creator: <span id="creator">John Smith</span></p>
+                        <p>Status: <span id="status"></span>Active</p>
                     </div>
                 </div>
                 <div class="body">
                     <p class="announcement-body">Lorem ipsum dolor sit amet</p>
                 </div>
+                <div class="change-status-delete">
+                    <div class="status">
+                        <form action="">
+                            <label for="change-status">Change status:</label>
+                            <select name="change-status">
+                                <option value="change status" selected disabled>Change status</option>
+                                <option value="active">Active</option>
+                                <option value="deactivated">Deactivated</option>
+                                <option value="accepted">Accepted</option>
+                                <option value="declined">Declined</option>
+                            </select>
+                            <input type="submit" value="OK">
+                        </form>
+                    </div>
+                </div>
             </div>`
-            })
+            });
     
             return oneUserAnnouncements.join('');
         });


### PR DESCRIPTION
# What does this PR do?

This is a page that allows the admin to change the status of an announcement

# Description of the task to be completed

- Create a responsive page
- Add a form with a drop-down containing active, deactivated, accepted and declined options
- Add a confirm button

# How should this be manually tested?

- Clone this repository, cd into /templates/html and open admin-dashboard.html
- Resize your browser to check its responsiveness
- Check the presence of a drop-down labeled change status
- Check the presence of an OK button

![Screenshot (26)](https://user-images.githubusercontent.com/52489421/72809103-a374ef80-3c63-11ea-911b-4c5247b4d181.png)
