### PR TITLE
#170842472 Delete announcement API endpoint

### DIFF
--- a/server/controllers/delete-announcement.js
+++ b/server/controllers/delete-announcement.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import announcements from '../data/announcements';
+import {
+  resourceNotFound,
+  accessDenied,
+  deletedSuccessfully
+} from '../helpers/response-messages';
+import authoriseUser from '../middlewares/authorisation';
+
+const deleteAnnouncementRouter = express.Router();
+
+deleteAnnouncementRouter.delete(
+  '/announcement/:id',
+  authoriseUser,
+  (req, res) => {
+    const announcementId = parseInt(req.params.id, 10);
+    const announcementOfInterest = announcements.find(
+      ann => ann.id === announcementId
+    );
+
+    const admin = req.user.is_admin;
+
+    if (!admin)
+      return res.status(401).json({
+        status: res.statusCode,
+        error: accessDenied
+      });
+
+    if (!announcementOfInterest)
+      return res.status(404).json({
+        error: res.statusCode,
+        message: resourceNotFound
+      });
+
+    const announcementIndex = announcements.indexOf(announcementOfInterest);
+
+    announcements.splice(announcementIndex, 1);
+    res.json({
+      status: 200,
+      message: deletedSuccessfully
+    });
+  }
+);
+
+export default deleteAnnouncementRouter;

--- a/server/helpers/response-messages.js
+++ b/server/helpers/response-messages.js
@@ -7,3 +7,5 @@ export const resourceNotFound = 'Resource not found';
 export const accessDenied = 'Access to this resource is denied';
 export const resourceNotModified =
   'The status was not modified. The former and current statuses are similar';
+export const updatedSuccessfully = 'Announcement updated successfully';
+export const deletedSuccessfully = 'Announcement deleted successfully';

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -4,6 +4,7 @@ import signinRouter from '../controllers/signin';
 import createAnnouncementRouter from '../controllers/create-announcement';
 import updateAnnouncementRouter from '../controllers/update-announcement';
 import changeStatusRouter from '../controllers/change-status';
+import deleteAnnouncementRouter from '../controllers/delete-announcement';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
+router.use('/api/v1/', deleteAnnouncementRouter);
 
 export default router;

--- a/server/tests/delete-announcement-test.js
+++ b/server/tests/delete-announcement-test.js
@@ -1,0 +1,104 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+import {
+  deletedSuccessfully,
+  resourceNotFound,
+  accessDenied
+} from '../helpers/response-messages';
+
+const { should } = chai;
+
+should();
+
+chai.use(chaiHttp);
+
+/* global describe, it */
+describe('Delete an announcement', () => {
+  describe('DELETE /announcement/:id', () => {
+    const adminData = {
+      id: 2,
+      email: 'johnsmith@gmail.com',
+      password: 'adminpassword',
+      is_admin: true
+    };
+
+    const randomData = {
+      email: 'samsmith@gmail.com',
+      password: 'mypassword'
+    };
+
+    const adminToken = generateToken(adminData);
+    const wrongToken = 'mdalnfalkdfhakhflahflahfl';
+    const randomToken = generateToken(randomData);
+
+    it('should return status 200 with an object whose status and message as properties', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/3')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(200);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'message']);
+          res.body.status.should.equal(200);
+          res.body.message.should.equal(deletedSuccessfully);
+        });
+      done();
+    });
+
+    it('should return status 401, If admin credentials are wrong', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/3')
+        .set('authorization', wrongToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'error']);
+          res.body.status.should.equal(401);
+          res.body.error.should.be.a('string');
+        });
+      done();
+    });
+
+    it('should return status 404, If the announcement is not found', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/300')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(404);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.equal(404);
+          res.body.message.should.equal(resourceNotFound);
+        });
+      done();
+    });
+
+    it('should return status 401 and access denied message, if the user deleting is not an admin', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/3')
+        .set('authorization', randomToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'error']);
+          res.body.status.should.equal(401);
+          res.body.error.should.equal(accessDenied);
+        });
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# What does this PR do?

It allows an admin to delete a user's announcement

# Description of the task to be completed

- Create a DELETE /announcement/:id endpoint
- Add authorization 
- Write tests for that specific endpoint

# How can this be manually tested?

- Clone this repository
- In your terminal type "npm run test"
- 22 tests should pass

# What are the relevant pivotal tracker stories?

#170842472