### PR TITLE
#170842257 View announcements of specific state API endpoint

### DIFF
--- a/server/controllers/all-specific-status-announcements.js
+++ b/server/controllers/all-specific-status-announcements.js
@@ -23,7 +23,7 @@ allSpecificStatusAnnouncementsRouter.get(
     );
 
     if (allAnnouncements.length === 0)
-      res.status(404).json({
+      return res.status(404).json({
         error: 404,
         message: resourceNotFound
       });

--- a/server/controllers/all-specific-status-announcements.js
+++ b/server/controllers/all-specific-status-announcements.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import authoriseUser from '../middlewares/authorisation';
+import { accessDenied, resourceNotFound } from '../helpers/response-messages';
+import announcements from '../data/announcements';
+
+const allSpecificStatusAnnouncementsRouter = express.Router();
+
+allSpecificStatusAnnouncementsRouter.get(
+  '/announcement/:status',
+  authoriseUser,
+  (req, res) => {
+    const { status } = req.params;
+    const { user } = req;
+
+    if (user.is_admin)
+      return res.status(401).json({
+        error: 401,
+        message: accessDenied
+      });
+
+    const allAnnouncements = announcements.filter(
+      ann => ann.owner === user.id && ann.status === status
+    );
+
+    if (allAnnouncements.length === 0)
+      res.status(404).json({
+        error: 404,
+        message: resourceNotFound
+      });
+
+    res.status(200).json({
+      status: res.statusCode,
+      data: allAnnouncements
+    });
+  }
+);
+
+export default allSpecificStatusAnnouncementsRouter;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -4,6 +4,7 @@ import signinRouter from '../controllers/signin';
 import createAnnouncementRouter from '../controllers/create-announcement';
 import updateAnnouncementRouter from '../controllers/update-announcement';
 import changeStatusRouter from '../controllers/change-status';
+import allSpecificStatusAnnouncementsRouter from '../controllers/all-specific-status-announcements';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
+router.use('/api/v1/', allSpecificStatusAnnouncementsRouter);
 
 export default router;

--- a/server/tests/all-specific-state-announcements-test.js
+++ b/server/tests/all-specific-state-announcements-test.js
@@ -1,0 +1,87 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+import { accessDenied, resourceNotFound } from '../helpers/response-messages';
+
+const { should } = chai;
+
+should();
+
+chai.use(chaiHttp);
+
+/* global describe, it */
+
+describe('Get all announcements of a specific state', () => {
+  describe('GET /announcement/:status', () => {
+    const userData = {
+      id: 1,
+      email: 'samsmith@gmail.com',
+      password: 'mypassword',
+      is_admin: false
+    };
+
+    const adminData = {
+      id: 2,
+      email: 'johnsmith@gmail.com',
+      password: 'adminpassword',
+      is_admin: true
+    };
+    const adminToken = generateToken(adminData);
+    const userToken = generateToken(userData);
+
+    it('should return status 200 and an object with status and data as properties', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/pending')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(200);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'data']);
+          res.body.status.should.equal(200);
+        });
+      done();
+    });
+
+    it('should return status 401, if announcements are requested by an admin', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/pending')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.equal(401);
+          res.body.message.should.be.a('string');
+          res.body.error.should.be.a('number');
+          res.body.message.should.equal(accessDenied);
+        });
+      done();
+    });
+
+    it('should return error 404, if no announcements of that specific status is found', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/deactivated')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(404);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.equal(404);
+          res.body.message.should.be.a('string');
+          res.body.error.should.be.a('number');
+          res.body.message.should.equal(resourceNotFound);
+        });
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# What does this PR do?

This is an API endpoint that allows users to view announcements of a specific state

# Description of the task to be completed

- Create GET announcement/:status endpoint
- Add authorization
- Write its tests

# How should this be manually tested?

- Clone this repository 
- In your terminal type "npm run test"

# What are the relevant pivotal tracker stories?

#170842257