### PR TITLE
#170842412 view all announcements from all users API endpoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node ./build/app.js
+web: babel-node server/app.js

--- a/server/controllers/admin-view-all-announcements.js
+++ b/server/controllers/admin-view-all-announcements.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import authorizeUser from '../middlewares/authorisation';
+import { accessDenied, resourceNotFound } from '../helpers/response-messages';
+import announcements from '../data/announcements';
+
+const adminAllAnnouncementsRouter = express.Router();
+
+adminAllAnnouncementsRouter.get('/announcement', authorizeUser, (req, res) => {
+  const isAdmin = req.user.is_admin;
+
+  if (!isAdmin)
+    return res.status(401).json({
+      status: res.statusCode,
+      error: accessDenied
+    });
+
+  if (announcements.length === 0)
+    return res.status(404).json({
+      error: res.statusCode,
+      message: resourceNotFound
+    });
+
+  res.status(200).json({
+    status: res.statusCode,
+    data: announcements
+  });
+});
+
+export default adminAllAnnouncementsRouter;

--- a/server/controllers/all-specific-status-announcements.js
+++ b/server/controllers/all-specific-status-announcements.js
@@ -23,7 +23,7 @@ allSpecificStatusAnnouncementsRouter.get(
     );
 
     if (allAnnouncements.length === 0)
-      res.status(404).json({
+      return res.status(404).json({
         error: 404,
         message: resourceNotFound
       });

--- a/server/controllers/all-specific-status-announcements.js
+++ b/server/controllers/all-specific-status-announcements.js
@@ -6,7 +6,7 @@ import announcements from '../data/announcements';
 const allSpecificStatusAnnouncementsRouter = express.Router();
 
 allSpecificStatusAnnouncementsRouter.get(
-  '/announcement/:status',
+  '/announcements/:status',
   authoriseUser,
   (req, res) => {
     const { status } = req.params;

--- a/server/controllers/all-specific-status-announcements.js
+++ b/server/controllers/all-specific-status-announcements.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import authoriseUser from '../middlewares/authorisation';
+import { accessDenied, resourceNotFound } from '../helpers/response-messages';
+import announcements from '../data/announcements';
+
+const allSpecificStatusAnnouncementsRouter = express.Router();
+
+allSpecificStatusAnnouncementsRouter.get(
+  '/announcement/:status',
+  authoriseUser,
+  (req, res) => {
+    const { status } = req.params;
+    const { user } = req;
+
+    if (user.is_admin)
+      return res.status(401).json({
+        error: 401,
+        message: accessDenied
+      });
+
+    const allAnnouncements = announcements.filter(
+      ann => ann.owner === user.id && ann.status === status
+    );
+
+    if (allAnnouncements.length === 0)
+      res.status(404).json({
+        error: 404,
+        message: resourceNotFound
+      });
+
+    res.status(200).json({
+      status: res.statusCode,
+      data: allAnnouncements
+    });
+  }
+);
+
+export default allSpecificStatusAnnouncementsRouter;

--- a/server/controllers/delete-announcement.js
+++ b/server/controllers/delete-announcement.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import announcements from '../data/announcements';
+import {
+  resourceNotFound,
+  accessDenied,
+  deletedSuccessfully
+} from '../helpers/response-messages';
+import authoriseUser from '../middlewares/authorisation';
+
+const deleteAnnouncementRouter = express.Router();
+
+deleteAnnouncementRouter.delete(
+  '/announcement/:id',
+  authoriseUser,
+  (req, res) => {
+    const announcementId = parseInt(req.params.id, 10);
+    const announcementOfInterest = announcements.find(
+      ann => ann.id === announcementId
+    );
+
+    const admin = req.user.is_admin;
+
+    if (!admin)
+      return res.status(401).json({
+        status: res.statusCode,
+        error: accessDenied
+      });
+
+    if (!announcementOfInterest)
+      return res.status(404).json({
+        error: res.statusCode,
+        message: resourceNotFound
+      });
+
+    const announcementIndex = announcements.indexOf(announcementOfInterest);
+
+    announcements.splice(announcementIndex, 1);
+    res.json({
+      status: 200,
+      message: deletedSuccessfully
+    });
+  }
+);
+
+export default deleteAnnouncementRouter;

--- a/server/controllers/view-specific-announcement.js
+++ b/server/controllers/view-specific-announcement.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import authoriseUser from '../middlewares/authorisation';
+import { resourceNotFound, accessDenied } from '../helpers/response-messages';
+import announcements from '../data/announcements';
+
+const viewSpecificAnnouncementRouter = express.Router();
+
+viewSpecificAnnouncementRouter.get(
+  '/announcement/:id',
+  authoriseUser,
+  (req, res) => {
+    const announcementId = parseInt(req.params.id, 10);
+    const { user } = req;
+
+    const announcementOfInterest = announcements.find(
+      ann => ann.id === announcementId && user.id === ann.owner
+    );
+
+    if (!announcementOfInterest)
+      return res.status(404).json({
+        error: res.statusCode,
+        message: resourceNotFound
+      });
+
+    res.status(200).json({
+      status: res.statusCode,
+      data: announcementOfInterest
+    });
+  }
+);
+
+export default viewSpecificAnnouncementRouter;

--- a/server/controllers/view-specific-announcement.js
+++ b/server/controllers/view-specific-announcement.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import authoriseUser from '../middlewares/authorisation';
-import { resourceNotFound, accessDenied } from '../helpers/response-messages';
+import { resourceNotFound } from '../helpers/response-messages';
 import announcements from '../data/announcements';
 
 const viewSpecificAnnouncementRouter = express.Router();

--- a/server/helpers/response-messages.js
+++ b/server/helpers/response-messages.js
@@ -7,3 +7,5 @@ export const resourceNotFound = 'Resource not found';
 export const accessDenied = 'Access to this resource is denied';
 export const resourceNotModified =
   'The status was not modified. The former and current statuses are similar';
+export const updatedSuccessfully = 'Announcement updated successfully';
+export const deletedSuccessfully = 'Announcement deleted successfully';

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -4,6 +4,7 @@ import signinRouter from '../controllers/signin';
 import createAnnouncementRouter from '../controllers/create-announcement';
 import updateAnnouncementRouter from '../controllers/update-announcement';
 import changeStatusRouter from '../controllers/change-status';
+import adminAllAnnouncementsRouter from '../controllers/admin-view-all-announcements';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
+router.use('/api/v1/', adminAllAnnouncementsRouter);
 
 export default router;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -7,6 +7,7 @@ import changeStatusRouter from '../controllers/change-status';
 import viewSpecificAnnouncementRouter from '../controllers/view-specific-announcement';
 import allSpecificStatusAnnouncementsRouter from '../controllers/all-specific-status-announcements';
 import deleteAnnouncementRouter from '../controllers/delete-announcement';
+import adminAllAnnouncementsRouter from '../controllers/admin-view-all-announcements';
 
 const router = express.Router();
 
@@ -18,5 +19,6 @@ router.use('/api/v1/', viewSpecificAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
 router.use('/api/v1/', allSpecificStatusAnnouncementsRouter);
 router.use('/api/v1/', deleteAnnouncementRouter);
+router.use('/api/v1/', adminAllAnnouncementsRouter);
 
 export default router;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -14,8 +14,8 @@ router.use('/api/v1/', signupRouter);
 router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
-router.use('/api/v1/', changeStatusRouter);
 router.use('/api/v1/', viewSpecificAnnouncementRouter);
+router.use('/api/v1/', changeStatusRouter);
 router.use('/api/v1/', allSpecificStatusAnnouncementsRouter);
 router.use('/api/v1/', deleteAnnouncementRouter);
 

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -4,6 +4,7 @@ import signinRouter from '../controllers/signin';
 import createAnnouncementRouter from '../controllers/create-announcement';
 import updateAnnouncementRouter from '../controllers/update-announcement';
 import changeStatusRouter from '../controllers/change-status';
+import deleteAnnouncementRouter from '../controllers/delete-announcement';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
+router.use('/api/v1/', deleteAnnouncementRouter);
 
 export default router;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -4,6 +4,7 @@ import signinRouter from '../controllers/signin';
 import createAnnouncementRouter from '../controllers/create-announcement';
 import updateAnnouncementRouter from '../controllers/update-announcement';
 import changeStatusRouter from '../controllers/change-status';
+import allSpecificStatusAnnouncementsRouter from '../controllers/all-specific-status-announcements';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
+router.use('/api/v1/', allSpecificStatusAnnouncementsRouter);
 
 export default router;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -4,6 +4,7 @@ import signinRouter from '../controllers/signin';
 import createAnnouncementRouter from '../controllers/create-announcement';
 import updateAnnouncementRouter from '../controllers/update-announcement';
 import changeStatusRouter from '../controllers/change-status';
+import viewSpecificAnnouncementRouter from '../controllers/view-specific-announcement';
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/api/v1/', signinRouter);
 router.use('/api/v1/', createAnnouncementRouter);
 router.use('/api/v1/', updateAnnouncementRouter);
 router.use('/api/v1/', changeStatusRouter);
+router.use('/api/v1/', viewSpecificAnnouncementRouter);
 
 export default router;

--- a/server/tests/admin-view-all-announcements-test.js
+++ b/server/tests/admin-view-all-announcements-test.js
@@ -1,0 +1,69 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+
+const { should } = chai;
+
+should();
+
+chai.use(chaiHttp);
+
+/* global describe, it */
+
+describe('View all announcements from all users', () => {
+  describe('GET /announcement', () => {
+    const adminData = {
+      id: 2,
+      email: 'johnsmith@gmail.com',
+      password: 'adminpassword',
+      is_admin: true
+    };
+
+    const regularUser = {
+      id: 1,
+      email: 'samsmith@gmail.com',
+      password: 'mypassword',
+      is_admin: false
+    };
+
+    const adminToken = generateToken(adminData);
+    const regularUserToken = generateToken(regularUser);
+
+    it('should return status 200 and an object whose status and data properties', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(200);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'data']);
+          res.body.status.should.be.a('number');
+          res.body.status.should.equal(200);
+          res.body.data.should.be.a('array');
+        });
+      done();
+    });
+
+    it('should return an error 401 and an object whose status and error as properties', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement')
+        .set('authorization', regularUserToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'error']);
+          res.body.status.should.be.a('number');
+          res.body.status.should.equal(401);
+          res.body.error.should.be.a('string');
+        });
+      done();
+    });
+  });
+});

--- a/server/tests/all-specific-state-announcements-test.js
+++ b/server/tests/all-specific-state-announcements-test.js
@@ -13,7 +13,7 @@ chai.use(chaiHttp);
 /* global describe, it */
 
 describe('Get all announcements of a specific state', () => {
-  describe('GET /announcement/:status', () => {
+  describe('GET /announcements/:status', () => {
     const userData = {
       id: 1,
       email: 'samsmith@gmail.com',
@@ -33,7 +33,7 @@ describe('Get all announcements of a specific state', () => {
     it('should return status 200 and an object with status and data as properties', done => {
       chai
         .request(app)
-        .get('/api/v1/announcement/pending')
+        .get('/api/v1/announcements/pending')
         .set('authorization', userToken)
         .end((err, res) => {
           if (err) return done(err);
@@ -49,7 +49,7 @@ describe('Get all announcements of a specific state', () => {
     it('should return status 401, if announcements are requested by an admin', done => {
       chai
         .request(app)
-        .get('/api/v1/announcement/pending')
+        .get('/api/v1/announcements/pending')
         .set('authorization', adminToken)
         .end((err, res) => {
           if (err) return done(err);
@@ -68,7 +68,7 @@ describe('Get all announcements of a specific state', () => {
     it('should return error 404, if no announcements of that specific status is found', done => {
       chai
         .request(app)
-        .get('/api/v1/announcement/deactivated')
+        .get('/api/v1/announcements/deactivated')
         .set('authorization', userToken)
         .end((err, res) => {
           if (err) return done(err);

--- a/server/tests/all-specific-state-announcements-test.js
+++ b/server/tests/all-specific-state-announcements-test.js
@@ -1,0 +1,87 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+import { accessDenied, resourceNotFound } from '../helpers/response-messages';
+
+const { should } = chai;
+
+should();
+
+chai.use(chaiHttp);
+
+/* global describe, it */
+
+describe('Get all announcements of a specific state', () => {
+  describe('GET /announcement/:status', () => {
+    const userData = {
+      id: 1,
+      email: 'samsmith@gmail.com',
+      password: 'mypassword',
+      is_admin: false
+    };
+
+    const adminData = {
+      id: 2,
+      email: 'johnsmith@gmail.com',
+      password: 'adminpassword',
+      is_admin: true
+    };
+    const adminToken = generateToken(adminData);
+    const userToken = generateToken(userData);
+
+    it('should return status 200 and an object with status and data as properties', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/pending')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(200);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'data']);
+          res.body.status.should.equal(200);
+        });
+      done();
+    });
+
+    it('should return status 401, if announcements are requested by an admin', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/pending')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.equal(401);
+          res.body.message.should.be.a('string');
+          res.body.error.should.be.a('number');
+          res.body.message.should.equal(accessDenied);
+        });
+      done();
+    });
+
+    it('should return error 404, if no announcements of that specific status is found', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/deactivated')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(404);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.equal(404);
+          res.body.message.should.be.a('string');
+          res.body.error.should.be.a('number');
+          res.body.message.should.equal(resourceNotFound);
+        });
+      done();
+    });
+  });
+});

--- a/server/tests/delete-announcement-test.js
+++ b/server/tests/delete-announcement-test.js
@@ -1,0 +1,104 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+import {
+  deletedSuccessfully,
+  resourceNotFound,
+  accessDenied
+} from '../helpers/response-messages';
+
+const { should } = chai;
+
+should();
+
+chai.use(chaiHttp);
+
+/* global describe, it */
+describe('Delete an announcement', () => {
+  describe('DELETE /announcement/:id', () => {
+    const adminData = {
+      id: 2,
+      email: 'johnsmith@gmail.com',
+      password: 'adminpassword',
+      is_admin: true
+    };
+
+    const randomData = {
+      email: 'samsmith@gmail.com',
+      password: 'mypassword'
+    };
+
+    const adminToken = generateToken(adminData);
+    const wrongToken = 'mdalnfalkdfhakhflahflahfl';
+    const randomToken = generateToken(randomData);
+
+    it('should return status 200 with an object whose status and message as properties', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/3')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(200);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'message']);
+          res.body.status.should.equal(200);
+          res.body.message.should.equal(deletedSuccessfully);
+        });
+      done();
+    });
+
+    it('should return status 401, If admin credentials are wrong', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/3')
+        .set('authorization', wrongToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'error']);
+          res.body.status.should.equal(401);
+          res.body.error.should.be.a('string');
+        });
+      done();
+    });
+
+    it('should return status 404, If the announcement is not found', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/300')
+        .set('authorization', adminToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(404);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.equal(404);
+          res.body.message.should.equal(resourceNotFound);
+        });
+      done();
+    });
+
+    it('should return status 401 and access denied message, if the user deleting is not an admin', done => {
+      chai
+        .request(app)
+        .delete('/api/v1/announcement/3')
+        .set('authorization', randomToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(401);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'error']);
+          res.body.status.should.equal(401);
+          res.body.error.should.equal(accessDenied);
+        });
+      done();
+    });
+  });
+});

--- a/server/tests/view-specific-announcement-test.js
+++ b/server/tests/view-specific-announcement-test.js
@@ -1,0 +1,76 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import generateToken from '../helpers/generate-token';
+import { resourceNotFound, accessDenied } from '../helpers/response-messages';
+
+const { should } = chai;
+
+should();
+
+chai.use(chaiHttp);
+
+/* global describe, it */
+describe('View specific announcement', () => {
+  describe('GET /announcement/:id', () => {
+    const userData = {
+      id: 1,
+      email: 'samsmith@gmail.com',
+      password: 'mypassword'
+    };
+
+    const differentUser = {
+      id: 2,
+      email: 'johnsmith@gmail.com',
+      password: 'adminpassword'
+    };
+
+    const userToken = generateToken(userData);
+    const differentUserToken = generateToken(differentUser);
+
+    it('should return status 200 and an object with status and data as properties', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/2')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(200);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['status', 'data']);
+          res.body.status.should.be.a('number');
+          res.body.data.should.be.a('object');
+          res.body.status.should.equal(200);
+          res.body.data.should.include.keys([
+            'id',
+            'owner',
+            'status',
+            'text',
+            'start_date',
+            'end_date'
+          ]);
+        });
+      done();
+    });
+
+    it('should return a 404 error and an resource not found message', done => {
+      chai
+        .request(app)
+        .get('/api/v1/announcement/21')
+        .set('authorization', userToken)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          res.status.should.equal(404);
+          res.body.should.be.a('object');
+          res.body.should.include.keys(['error', 'message']);
+          res.body.error.should.be.a('number');
+          res.body.message.should.be.a('string');
+          res.body.error.should.equal(404);
+          res.body.message.should.equal(resourceNotFound);
+        });
+      done();
+    });
+  });
+});

--- a/server/tests/view-specific-announcement-test.js
+++ b/server/tests/view-specific-announcement-test.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../app';
 import generateToken from '../helpers/generate-token';
-import { resourceNotFound, accessDenied } from '../helpers/response-messages';
+import { resourceNotFound } from '../helpers/response-messages';
 
 const { should } = chai;
 
@@ -19,14 +19,7 @@ describe('View specific announcement', () => {
       password: 'mypassword'
     };
 
-    const differentUser = {
-      id: 2,
-      email: 'johnsmith@gmail.com',
-      password: 'adminpassword'
-    };
-
     const userToken = generateToken(userData);
-    const differentUserToken = generateToken(differentUser);
 
     it('should return status 200 and an object with status and data as properties', done => {
       chai


### PR DESCRIPTION
# What does this PR do?

This endpoint enables the admin to view all announcements from all users

# Description of the task to be completed

- Create GET /announcement endpoint
- Add authorization
- Write tests

# How should this be manually tested?

- Clone this repository
- In your terminal type "npm run test"
- All tests should be passing

# What are the relevant pivotal tracker stories?

#170842412